### PR TITLE
Simplify web jar creation

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,4 +52,4 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "example-component-library"
 
 // Include all subprojects in the build
-include(":common", ":gateway", ":designer", ":web")
+include(":", ":common", ":gateway", ":designer", ":web")

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -42,7 +42,9 @@ val webpack by tasks.registering(NpmTask::class) {
 tasks {
     // Ensure webpack runs before processing resources
 	processResources {
-		dependsOn(webpack)	
+		dependsOn(webpack)
+        // Include webpack output in jar
+        from(projectOutput) { into("") }
 	}
 
     // Clean up the dist directory
@@ -59,16 +61,4 @@ val deepClean by tasks.registering {
     }
 
     dependsOn(project.tasks.named("clean"))
-}
-
-// Ensure the gateway project waits for web resources
-project(":gateway")?.tasks?.named("processResources")?.configure {
-    dependsOn(webpack)
-}
-
-// Configure where the web resources end up
-sourceSets {
-    main {
-        output.dir(projectOutput, "builtBy" to listOf(webpack))
-    }
 }


### PR DESCRIPTION
1. Root project should be included.
2. The webpack output isn't really a source set, it's just a set of files you want to copy into the jar. So let's just copy them from the output directory to the root of the jar.
3. The gateway project does not need to wait for the web project. The dependency is already handled through `modlImplementation(projects.web)`.